### PR TITLE
Java-API-Client uses multi-stage docker build

### DIFF
--- a/demos/java-api-client/Dockerfile
+++ b/demos/java-api-client/Dockerfile
@@ -1,4 +1,27 @@
-FROM openjdk:8-jre-alpine
-ADD target/ConjurJavaClient-1.0-SNAPSHOT-with-dependencies.jar ConjurJavaClient-1.0-SNAPSHOT-with-dependencies.jar
-ENTRYPOINT ["java", "-jar", "ConjurJavaClient-1.0-SNAPSHOT-with-dependencies.jar"]
+# =================== BUILD API CONTAINER ===================
+FROM maven:3-openjdk-8 as conjur-api-builder
+MAINTAINER Cyberark Inc.
+LABEL builder="java-api-builder"
 
+RUN git clone https://github.com/cyberark/conjur-api-java.git
+
+WORKDIR conjur-api-java
+
+RUN mvn install -DskipTests -Dmaven.javadoc.skip=true
+
+# =================== MAIN CONTAINER ===================
+FROM maven:3-openjdk-8 as java-client
+ARG VERSION
+
+ADD . .
+
+COPY --from=conjur-api-builder conjur-api-java/target/conjur-api-"$VERSION"-with-dependencies.jar .
+
+RUN mvn install:install-file \
+-Dfile=conjur-api-2.2.1-with-dependencies.jar \
+-DgroupId=net.conjur.api -DartifactId=conjur-api -Dversion="$VERSION" \
+-Dpackaging=jar
+
+RUN mvn install -Dconjur-api-version="$VERSION"
+
+ENTRYPOINT ["java", "-jar", "target/ConjurJavaClient-1.0-SNAPSHOT-with-dependencies.jar"]

--- a/demos/java-api-client/build.sh
+++ b/demos/java-api-client/build.sh
@@ -13,8 +13,6 @@ function validate_app {
   fi
 }
 
-validate_app git
-validate_app mvn
 validate_app docker
 
 COMMAND=$0
@@ -23,54 +21,7 @@ suffix="/build.sh";
 HOME_DIR=${COMMAND%$suffix};
 pushd $HOME_DIR
 
-rm -rf target
-rm -rf conjur-api-java
-
-echo "Cloning Conjur Java SDK repository from Github"
-
-git clone https://github.com/cyberark/conjur-api-java.git
-
-if [ ! -d "./conjur-api-java" ]
-then
-  echo "Git clone failed"
-  exit 1
-fi
-
-BRANCH_NAME=$( git rev-parse --abbrev-ref HEAD )
-
-git checkout $BRANCH_NAME
-
-pushd conjur-api-java
-
-echo "Building Conjur Java SDK JAR"
-
-mvn install -DskipTests -Dmaven.javadoc.skip=true
-
-popd
-
-API_JAR_NAME=$( ls conjur-api-java/target/*with-dependencies.jar | grep conjur-api )
-echo "API_JAR_NAME=$API_JAR_NAME"
-if [ -z $API_JAR_NAME ]
-then
-  echo "Maven install Conjur Java SDK jar failed"
-  exit 1
-fi
-
-VERSION=$( echo "$API_JAR_NAME"| cut -d'/' -f 3 | cut -d'-' -f 3 )
-
-echo "Installing Conjur Java SDK JAR to Maven Repo"
-
-mvn install:install-file -Dfile=conjur-api-java/target/conjur-api-$VERSION-with-dependencies.jar -DgroupId=net.conjur.api -DartifactId=conjur-api -Dversion=$VERSION -Dpackaging=jar
-
-echo "Build Conjur Java Client Example"
-mvn install -Dconjur-api-version=2.1.0
-
-cp conjur-api-java/target/conjur-api-2.1.0-with-dependencies.jar .
-
-rm -rf conjur-api-java
-
 echo "Creating docker image of Conjur Java Client Example"
-docker build -f Dockerfile -t conjur-java-client .
+docker build -f Dockerfile --build-arg VERSION=2.2.1 -t conjur-java-client .
 
 docker images | grep conjur-java-client
-


### PR DESCRIPTION
- Remove conjur-java-api build directives from `build.sh`
- Convert `Dockerfile` to use a two-stage build to first build the API jar file,
 then build the client jar file with dependencies