### PR TITLE
Update Jave API Client to use Maven Central dependency

### DIFF
--- a/demos/java-api-client/Dockerfile
+++ b/demos/java-api-client/Dockerfile
@@ -1,4 +1,9 @@
-FROM openjdk:8-jre-alpine
-ADD target/ConjurJavaClient-1.0-SNAPSHOT-with-dependencies.jar ConjurJavaClient-1.0-SNAPSHOT-with-dependencies.jar
+FROM maven:3-openjdk-8
+MAINTAINER Cyberark Inc.
+
+ADD . .
+
+RUN mvn install
+
 ENTRYPOINT ["java", "-jar", "ConjurJavaClient-1.0-SNAPSHOT-with-dependencies.jar"]
 

--- a/demos/java-api-client/build.sh
+++ b/demos/java-api-client/build.sh
@@ -14,7 +14,6 @@ function validate_app {
 }
 
 validate_app git
-validate_app mvn
 validate_app docker
 
 COMMAND=$0
@@ -22,52 +21,6 @@ echo "$COMMAND"
 suffix="/build.sh";
 HOME_DIR=${COMMAND%$suffix};
 pushd $HOME_DIR
-
-rm -rf target
-rm -rf conjur-api-java
-
-echo "Cloning Conjur Java SDK repository from Github"
-
-git clone https://github.com/cyberark/conjur-api-java.git
-
-if [ ! -d "./conjur-api-java" ]
-then
-  echo "Git clone failed"
-  exit 1
-fi
-
-BRANCH_NAME=$( git rev-parse --abbrev-ref HEAD )
-
-git checkout $BRANCH_NAME
-
-pushd conjur-api-java
-
-echo "Building Conjur Java SDK JAR"
-
-mvn install -DskipTests -Dmaven.javadoc.skip=true
-
-popd
-
-API_JAR_NAME=$( ls conjur-api-java/target/*with-dependencies.jar | grep conjur-api )
-echo "API_JAR_NAME=$API_JAR_NAME"
-if [ -z $API_JAR_NAME ]
-then
-  echo "Maven install Conjur Java SDK jar failed"
-  exit 1
-fi
-
-VERSION=$( echo "$API_JAR_NAME"| cut -d'/' -f 3 | cut -d'-' -f 3 )
-
-echo "Installing Conjur Java SDK JAR to Maven Repo"
-
-mvn install:install-file -Dfile=conjur-api-java/target/conjur-api-$VERSION-with-dependencies.jar -DgroupId=net.conjur.api -DartifactId=conjur-api -Dversion=$VERSION -Dpackaging=jar
-
-echo "Build Conjur Java Client Example"
-mvn install -Dconjur-api-version=2.1.0
-
-cp conjur-api-java/target/conjur-api-2.1.0-with-dependencies.jar .
-
-rm -rf conjur-api-java
 
 echo "Creating docker image of Conjur Java Client Example"
 docker build -f Dockerfile -t conjur-java-client .

--- a/demos/java-api-client/pom.xml
+++ b/demos/java-api-client/pom.xml
@@ -11,9 +11,9 @@
     <version>1.0-SNAPSHOT</version>
     <dependencies>
         <dependency>
-            <groupId>net.conjur.api</groupId>
+            <groupId>com.cyberark.conjur.api</groupId>
             <artifactId>conjur-api</artifactId>
-            <version>${conjur-api-version}</version>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
     <build><plugins>

--- a/demos/java-api-client/src/main/java/com/cyberark/example/JavaClient.java
+++ b/demos/java-api-client/src/main/java/com/cyberark/example/JavaClient.java
@@ -1,7 +1,7 @@
 package com.cyberark.example;
 
-import net.conjur.api.Conjur;
-import net.conjur.api.Token;
+import com.cyberark.conjur.api.Conjur;
+import com.cyberark.conjur.api.Token;
 
 import java.io.FileOutputStream;
 import java.io.PrintWriter;


### PR DESCRIPTION
The build script for the Java API client
has been shortened, now building entirely in docker and
requiring just the dependency for the Conjur API, rather
than needing to clone and build the project locally.