### PR TITLE
fixing a broken link to seccomp.json

### DIFF
--- a/tools/performance-tests/docker-compose.yml
+++ b/tools/performance-tests/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "443:443"
     security_opt:
-        - "seccomp:../seccomp.json"
+        - "seccomp:../../seccomp.json"
     volumes:
       - ../config:/opt/config:Z
       - ../logs:/var/log/conjur:z


### PR DESCRIPTION
Hi

This PR fix a broken link to seccomp.json file from the docker-compose of the performance-tests tool