### PR TITLE
update seccomp file location

### DIFF
--- a/tools/performance-tests/docker-compose.yml
+++ b/tools/performance-tests/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "443:443"
     security_opt:
-        - "seccomp:../seccomp.json"
+        - "seccomp:../../seccomp.json"
     volumes:
       - ../config:/opt/config:Z
       - ../logs:/var/log/conjur:z


### PR DESCRIPTION
The performance test location was moved and no longer referenced the right seccomp location. This was causing errors when running `bin/run`. This update fixes those errors.