### PR TITLE
DAP Intro Cleanups

### DIFF
--- a/artifacts/api-client/Dockerfile
+++ b/artifacts/api-client/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine:3
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl jq

--- a/bin/cli
+++ b/bin/cli
@@ -4,7 +4,7 @@ function proxy_command {
   cmd="$@"
   docker-compose run --rm -w /src/cli --entrypoint /bin/bash client -c "
     if [ ! -e /root/conjur-demo.pem ]; then
-      yes 'yes' | conjur init -u https://conjur-master-1.mycompany.local -a demo
+      yes 'yes' | conjur init -u https://conjur-master.mycompany.local -a demo
     fi
     conjur authn login -u admin -p MySecretP@ss1
     hostname -I

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
         ipv4_address: 12.16.23.17
     working_dir:  /src/cli
     environment:
-      CONJUR_APPLIANCE_URL: https://conjur-master-1.mycompany.local
+      CONJUR_APPLIANCE_URL: https://conjur-master.mycompany.local
       CONJUR_ACCOUNT: demo
       CONJUR_AUTHN_LOGIN: admin
     volumes:


### PR DESCRIPTION
This PR fixes to issues in the DAP Intro project:
- Adds the missing `jq` executable to the API client container image.
- Updates the CLI client to connect to the Master LB, rather than a specific Master node.

Connected to #76