### PR TITLE
Fix: update account name in instructions and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ bin/api --fetch-secrets
 |--import-custom-certificates|action|• Imports pre-generated 3rd-party certificates|Requires configured master|
 |--promote-standby|action|• Stops the current master<br>• Promotes a standby| Requires configured standbys and no auto-failover|
 |--provision-follower|action|• Removes follower if present<br>• Starts a DAP container and a Layer 7 load balancer<br>• Generates a follower seed<br>• Configures follower|Requires configured master|
-|--provision-master|action|• Starts a DAP container and Layer 4 load balancer<br>• Configures with account `default` and password `MySecretP@ss1`||
+|--provision-master|action|• Starts a DAP container and Layer 4 load balancer<br>• Configures with account `demo` and password `MySecretP@ss1`||
 |--provision-standbys|action|• Removes standbys if present<br>• Starts two DAP containers<br>• Generates standby seed files<br>• Configures standbys<br>• Enable Synchronous Standby|Requires configured master|
 |--restore-from-backup|action|• Removes auto-failover (if enabled)<br>• Stops and renames master<br>• Starts new DAP container<br>• Restores master from backup|Requires a previously created backup|
 |--stop|action|Stops and removes all containers||
@@ -103,7 +103,7 @@ $ bin/dap --provision-master
 
 This instance runs behind an HAProxy load balancer and is available at: [https://localhost].  Login:
 
-- Account `default`
+- Account `demo`
 - User: `admin`
 - Password: `MySecretP@ss1`
 
@@ -119,7 +119,7 @@ $ bin/dap --provision-follower
 
 This instance runs behind an HAProxy load balancer and is available at: [https://localhost].  Login:
 
-- Account `default`
+- Account `demo`
 - User: `admin`
 - Password: `MySecretP@ss1`
 
@@ -137,7 +137,7 @@ Usage: bin/dap single [options]
     --import-custom-certificates  Imports pre-generated 3rd-party certificates (Requires configured master)
     --promote-standby             Stops the current master and promotes a standby (Requires configured standbys and no auto-failover)
     --provision-follower          Configures follower behind a Layer 7 load balancer (Requires configured master)
-    --provision-master            Configures a DAP Master with account `default` and password `MySecretP@ss1` behind a Layer 4 load balancer
+    --provision-master            Configures a DAP Master with account `demo` and password `MySecretP@ss1` behind a Layer 4 load balancer
     --provision-standbys          Deploys and configures two standbys (Requires configured master)
     --restore-from-backup         Restores a master from backup|Requires a previously created backup
     --stop                        Stops all containers and cleans up cached files

--- a/bin/dap
+++ b/bin/dap
@@ -17,7 +17,7 @@ Usage: bin/dap [options]:
     --import-custom-certificates  Imports pre-generated 3rd-party certificates (Requires configured master)
     --promote-standby             Stops the current master and promotes a standby (Requires configured standbys and no auto-failover)
     --provision-follower          Configures follower behind a Layer 7 load balancer (Requires configured master)
-    --provision-master            Configures a DAP Master with account `default` and password `MySecretP@ss1` behind a Layer 4 load balancer
+    --provision-master            Configures a DAP Master with account `demo` and password `MySecretP@ss1` behind a Layer 4 load balancer
     --provision-standbys          Deploys and configures two standbys (Requires configured master)
     --restore-from-backup         Restores a master from backup|Requires a previously created backup
     --stop                        Stops all containers and cleans up cached files

--- a/tools/simple-policy-test-v5/README.md
+++ b/tools/simple-policy-test-v5/README.md
@@ -11,10 +11,10 @@ $ ./apply-and-watch <MASTER_HOSTNAME> <ACCOUNT> <ADMIN_API_KEY> [<FOLLOWER_HOSTN
 
 Example with both master and follower:
 ```
-$ ./apply-and-watch master.myorg.com default supersecretapikey follower.myorg.com
+$ ./apply-and-watch master.myorg.com demo supersecretapikey follower.myorg.com
 ```
 
 Example with no follower:
 ```
-$ ./apply-and-watch master.myorg.com default supersecretapikey
+$ ./apply-and-watch master.myorg.com demo supersecretapikey
 ```


### PR DESCRIPTION
[A while back](https://github.com/conjurdemos/dap-intro/commit/24583490134ce2836cae8830504065acdcde5e11) the CONJUR_ACCOUNT was standardised to `demo`. There are a quit few places where the account is stated erroneously as `default`. This PR fixes that.

Resolves https://github.com/conjurdemos/dap-intro/issues/82