### PR TITLE
Adds End-to-End testing for a DAP release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'cucumber'
+gem 'rspec-expectations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,75 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.3.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    builder (3.2.4)
+    concurrent-ruby (1.1.7)
+    cucumber (5.2.0)
+      builder (~> 3.2, >= 3.2.4)
+      cucumber-core (~> 8.0, >= 8.0.1)
+      cucumber-create-meta (~> 2.0, >= 2.0.2)
+      cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
+      cucumber-gherkin (~> 15.0, >= 15.0.2)
+      cucumber-html-formatter (~> 9.0, >= 9.0.0)
+      cucumber-messages (~> 13.1, >= 13.1.0)
+      cucumber-wire (~> 4.0, >= 4.0.1)
+      diff-lcs (~> 1.4, >= 1.4.4)
+      multi_test (~> 0.1, >= 0.1.2)
+      sys-uname (~> 1.2, >= 1.2.1)
+    cucumber-core (8.0.1)
+      cucumber-gherkin (~> 15.0, >= 15.0.2)
+      cucumber-messages (~> 13.0, >= 13.0.1)
+      cucumber-tag-expressions (~> 2.0, >= 2.0.4)
+    cucumber-create-meta (2.0.4)
+      cucumber-messages (~> 13.1, >= 13.1.0)
+      sys-uname (~> 1.2, >= 1.2.1)
+    cucumber-cucumber-expressions (10.3.0)
+    cucumber-gherkin (15.0.2)
+      cucumber-messages (~> 13.0, >= 13.0.1)
+    cucumber-html-formatter (9.0.0)
+      cucumber-messages (~> 13.0, >= 13.0.1)
+    cucumber-messages (13.2.1)
+      protobuf-cucumber (~> 3.10, >= 3.10.8)
+    cucumber-tag-expressions (2.0.4)
+    cucumber-wire (4.0.1)
+      cucumber-core (~> 8.0, >= 8.0.1)
+      cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
+      cucumber-messages (~> 13.0, >= 13.0.1)
+    diff-lcs (1.4.4)
+    ffi (1.13.1)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
+    middleware (0.1.0)
+    minitest (5.14.2)
+    multi_test (0.1.2)
+    protobuf-cucumber (3.10.8)
+      activesupport (>= 3.2)
+      middleware
+      thor
+      thread_safe
+    rspec-expectations (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.0)
+    sys-uname (1.2.2)
+      ffi (~> 1.1)
+    thor (1.0.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.8)
+      thread_safe (~> 0.1)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cucumber
+  rspec-expectations
+
+BUNDLED WITH
+   2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require 'rubygems'
+require 'cucumber'
+require 'cucumber/rake/task'
+require 'rspec/expectations'
+
+Cucumber::Rake::Task.new(:features) do |t|
+  t.cucumber_opts = "--format pretty" # Any valid command line option can go here.
+  include RSpec::Matchers
+end

--- a/artifacts/api-client/api-script
+++ b/artifacts/api-client/api-script
@@ -125,7 +125,7 @@ function fetch_secrets {
 
 function retrieve_variables {
   secrets="demo:variable:staging/my-app-1/postgres-database/url,demo:variable:staging/my-app-1/postgres-database/port,demo:variable:staging/my-app-1/postgres-database/username,demo:variable:staging/my-app-1/postgres-database/password"
-  fetch_secrets $secrets | jq .
+  fetch_secrets $secrets
 }
 
 function load_policy_and_set_variables {

--- a/bin/dap
+++ b/bin/dap
@@ -327,7 +327,7 @@ function _wait_for_master {
   done
 }
 
-prepare_configuration() {
+create_docker_network() {
   dap_net_pid=$(docker network ls --quiet --filter name=dap_net)
 
   if [[ -z "$dap_net_pid" ]]; then
@@ -336,7 +336,7 @@ prepare_configuration() {
       --ipam-driver default \
       --subnet 12.16.23.0/27 \
       dap_net
-    fi
+  fi
 }
 
 TAG=5.0-stable
@@ -368,6 +368,6 @@ done
 
 export VERSION=$TAG
 
-prepare_configuration
+create_docker_network
 
 eval $CMD

--- a/bin/dap
+++ b/bin/dap
@@ -325,6 +325,7 @@ function _wait_for_master {
     sleep 1
     echo "Successful Health Checks: $COUNTER"
   done
+}
 
 prepare_configuration() {
   dap_net_pid=$(docker network ls --quiet --filter name=dap_net)

--- a/bin/dap
+++ b/bin/dap
@@ -143,6 +143,7 @@ function _single_master {
   _start_master
   _configure_master
   echo "DAP instance available at: 'https://localhost'"
+  echo "Login using with the username/password: 'admin'/'$_admin_password'"
 }
 
 function _reload_container {
@@ -165,12 +166,14 @@ function _setup_standbys {
 function _stop {
   echo "stopping...."
   docker-compose down -v
+  docker network remove dap_net || true
 
   rm -rf cli_cache
   rm -rf system/backup/
   rm -rf system/logs/
   rm files/haproxy/master/haproxy.cfg || true
   echo "stopped"
+  exit
 }
 
 function _cli {
@@ -195,9 +198,9 @@ function _disable_autofailover {
 }
 
 function _enable_autofailover {
+  autofailover=$(curl -k https://conjur-master.mycompany.local/info | jq -r .configuration.conjur.cluster_name)
 
-  autofailover=$(curl -k https://localhost/info | jq .configuration.conjur.cluster_name)
-  if [[ $autofailover = 'production' ]]; then
+  if [ "$autofailover" = 'production' ]; then
     _run conjur-master-2.mycompany.local "evoke cluster enroll --reenroll --cluster-machine-name conjur-master-2.mycompany.local --master-name conjur-master-1.mycompany.local production"
     _run conjur-master-3.mycompany.local "evoke cluster enroll --reenroll --cluster-machine-name conjur-master-3.mycompany.local --master-name conjur-master-1.mycompany.local production"
   else
@@ -230,10 +233,9 @@ function _stop_and_rename {
 function _upgrade_via_backup_restore {
   upgrade_to="$1"
 
-  autofailover=$(curl -k https://localhost/info | jq .configuration.conjur.cluster_name)
+  autofailover=$(curl -k https://conjur-master.mycompany.local/info | jq -r .configuration.conjur.cluster_name)
 
-  # jq returns a quoted string, so we need to check for: "production" instead of: production (without double quotes)
-  if [ "$autofailover" = '"production"' ]; then
+  if [ "$autofailover" = 'production' ]; then
     _disable_autofailover
   fi
   _upgrade_master_via_backup_restore $upgrade_to
@@ -323,13 +325,23 @@ function _wait_for_master {
     sleep 1
     echo "Successful Health Checks: $COUNTER"
   done
+
+prepare_configuration() {
+  dap_net_pid=$(docker network ls --quiet --filter name=dap_net)
+
+  if [[ -z "$dap_net_pid" ]]; then
+    docker network create \
+      --driver bridge \
+      --ipam-driver default \
+      --subnet 12.16.23.0/27 \
+      dap_net
+    fi
 }
 
 TAG=5.0-stable
 DRY_RUN=false
-PULL_IMAGES=true
+PULL_IMAGES=false
 CMD=""
-to_version=""
 
 while true ; do
   case "$1" in
@@ -354,5 +366,7 @@ while true ; do
 done
 
 export VERSION=$TAG
+
+prepare_configuration
 
 eval $CMD

--- a/ci/README.md
+++ b/ci/README.md
@@ -16,8 +16,8 @@ ci/bin/end-to-end-tests
 
 When a new release candidate is ready to be added, three changes must be made in this repository:
 
-1. Add the version to line 3 of [/ci/bin/end-to-end-tests](../ci/bin/end-to-end-tests)
-2. Update `@current_version` on line 4 in [/features/step_definitions/world.rb](../features/step_definitions/world.rb)
+1. Add the version to line 5 of [/ci/bin/end-to-end-tests](../ci/bin/end-to-end-tests)
+2. Update `CURRENT_VERSION` on line 6 in [/features/step_definitions/world.rb](../features/step_definitions/world.rb)
 3. Add a the previously "Current" version to the `releases` table in [/features/cluster.feature](../features/cluster.feature)
 
 ## Development
@@ -26,7 +26,7 @@ These end-to-end tests were designed to be run against multiple environments and
 
 ### Adding a new Environment
 
-In order to implement a new environment, an environment specific provider must be created. This provider must implement the interface defined in [/ci/providers/interface.rb](../ci/providers/interface.rb).  The Provider should handle both component setup (VM/LB provisioning and configuration) as well as inspection. [CI::Providers::DockerCompose](../ci/providers/docker_compose.rb) can be used as an example.
+In order to implement a new environment, an environment specific provider must be created. This provider must implement the interface defined in [/ci/providers/provider_interface.rb](../ci/providers/provider_interface.rb).  The Provider should handle both component setup (VM/LB provisioning and configuration) as well as inspection. [CI::Providers::DockerCompose](../ci/providers/docker_compose.rb) can be used as an example.
 
 Once the Provider has been completed, it must be added to:
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,35 @@
+# DAP End-to-End Tests
+
+For now, DAP-Intro includes a set of End-to-End tests. These tests are intended to validate common customer workflows. The current set of scenarios can be found [here](../features/cluster.feature).
+
+End-to-End tests are platform agnostic. This means the same set of scenarios are run against a set of supported environments. Docker Compose is the only currently supported environment.
+
+## Running End-to-End Tests
+
+To run the end-to-end test suite:
+
+```
+ci/bin/end-to-end-tests
+```
+
+## Adding new Release Versions
+
+When a new release candidate is ready to be added, three changes must be made in this repository:
+
+1. Add the version to line 3 of [/ci/bin/end-to-end-tests](../ci/bin/end-to-end-tests)
+2. Update `@current_version` on line 4 in [/features/step_definitions/world.rb](../features/step_definitions/world.rb)
+3. Add a the previously "Current" version to the `releases` table in [/features/cluster.feature](../features/cluster.feature)
+
+## Development
+
+These end-to-end tests were designed to be run against multiple environments and configurations. Currently, Docker Compose is the available provider. It's intended that cloud providers like AWS, Azure, and GCP are added in the future. We can also support additional runtime environments like Podman.
+
+### Adding a new Environment
+
+In order to implement a new environment, an environment specific provider must be created. This provider must implement the interface defined in [/ci/providers/interface.rb](../ci/providers/interface.rb).  The Provider should handle both component setup (VM/LB provisioning and configuration) as well as inspection. [CI::Providers::DockerCompose](../ci/providers/docker_compose.rb) can be used as an example.
+
+Once the Provider has been completed, it must be added to:
+
+- [/features/step_definitions/world.rb](../features/step_definitions/world.rb) - sets provider for each run
+- [/features/support/env.rb](../features/support/env.rb) - handles cleanup after all scenarios have been run
+- [/ci/bin/end-to-end-tests](../ci/bin/end-to-end-tests) - list of providers to run tests against

--- a/ci/assets/Dockerfile.ci
+++ b/ci/assets/Dockerfile.ci
@@ -1,0 +1,16 @@
+FROM ruby:2.7-alpine
+
+RUN apk update && apk add --no-cache docker-cli git libffi-dev build-base bash jq curl
+
+# Install Docker-Compose
+RUN apk add --no-cache docker-cli python3 py3-pip && \
+    apk add --no-cache --virtual .docker-compose-deps python3-dev libffi-dev openssl-dev gcc libc-dev make && \
+    pip3 install docker-compose && \
+    apk del .docker-compose-deps
+
+RUN mkdir -p /src
+WORKDIR /src
+
+COPY Gemfile /src/Gemfile
+COPY Gemfile.lock /src/Gemfile.lock
+RUN bundle install

--- a/ci/bin/end-to-end-tests
+++ b/ci/bin/end-to-end-tests
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+
+versions=('5.12.4' '11.6.0' '11.7.0')
+
+prepare() {
+  # With Docker in Docker, the network context seems not to be passed correctly
+  docker network prune --force
+  docker network create \
+    --driver bridge \
+    --ipam-driver default \
+    --subnet 12.16.23.0/27 \
+    dap_net
+
+  # Docker in Docker container won't have permission to pull images, so
+  # we need to pull them before we start.
+  for version in "${versions[@]}"; do
+    docker pull registry2.itci.conjur.net/conjur-appliance:$version
+  done
+
+  # Build Docker in Docker image
+  docker build -t cucumber --file ci/assets/Dockerfile.ci .
+}
+
+# Prepare the exterior environment for Docker in Docker
+prepare
+
+# Array of providers to run end-to-end tests against
+providers=('docker')
+
+for provider in "${providers[@]}"; do
+  docker run \
+    --rm \
+    -it \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    --network dap_net \
+    -v $(pwd):$(pwd) \
+    --env PROVIDER=$provider \
+    --workdir $(pwd) \
+    cucumber /bin/bash -c "rake features"
+done

--- a/ci/bin/end-to-end-tests
+++ b/ci/bin/end-to-end-tests
@@ -1,9 +1,14 @@
 #!/bin/bash -e
+set -o pipefail
 
-versions=('5.12.4' '11.6.0' '11.7.0')
+# Array of versions to be used in testing
+versions=('11.6.0' '11.7.0' '12.0.0')
+# Array of providers to run end-to-end tests against
+providers=('docker')
 
-prepare() {
-  # With Docker in Docker, the network context seems not to be passed correctly
+prepare_environment() {
+  # With Docker in Docker, the network context seems not to be passed correctly.
+  # We'll create it here and provide it to the Docker Compose.
   docker network prune --force
   docker network create \
     --driver bridge \
@@ -21,20 +26,22 @@ prepare() {
   docker build -t cucumber --file ci/assets/Dockerfile.ci .
 }
 
-# Prepare the exterior environment for Docker in Docker
-prepare
 
-# Array of providers to run end-to-end tests against
-providers=('docker')
+main() {
+  # Prepare the exterior environment for Docker in Docker
+  prepare_environment
 
-for provider in "${providers[@]}"; do
-  docker run \
-    --rm \
-    -it \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    --network dap_net \
-    -v $(pwd):$(pwd) \
-    --env PROVIDER=$provider \
-    --workdir $(pwd) \
-    cucumber /bin/bash -c "rake features"
-done
+  for provider in "${providers[@]}"; do
+    docker run \
+      --rm \
+      -it \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      --network dap_net \
+      -v "$(pwd):$(pwd)" \
+      --env PROVIDER=$provider \
+      --workdir "$(pwd)" \
+      cucumber /bin/bash -c "rake features"
+  done
+}
+
+main

--- a/ci/providers/docker_compose.rb
+++ b/ci/providers/docker_compose.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require './ci/providers/interface'
+
+require 'json'
+require 'net/https'
+require 'uri'
+
+
+module CI
+  module Providers
+    # CI::Providers::DockerCompose enables Cucumber features to be run against
+    # DAP configured in Docker Compose.
+    #
+    # The DockerCompose class implements the public methods for the generic
+    # CI::Providers::Interface using Docker Compose.
+    class DockerCompose < Interface
+
+      def provision_master(version:, with_load_balancer: true)
+        system('cp files/haproxy/master/single/haproxy.cfg files/haproxy/master/haproxy.cfg')
+        system({ 'VERSION' => version }, 'docker-compose up -d --no-deps conjur-master.mycompany.local conjur-master-1.mycompany.local')
+        args = [
+          'evoke configure master',
+          '--accept-eula',
+          '--hostname conjur-master.mycompany.local',
+          '--master-altnames conjur-master-1.mycompany.local,conjur-master-2.mycompany.local,conjur-master-3.mycompany.local',
+          '--admin-password MySecretP@ss1',
+          'demo'
+        ].join(' ')
+        system("docker-compose exec conjur-master-1.mycompany.local bash -c '#{args}'")
+      end
+
+      def provision_follower(version:, with_load_balancer: true)
+        system({ 'VERSION' => version }, 'docker-compose up --no-deps --detach conjur-follower-1.mycompany.local')
+        system('docker-compose exec conjur-master-1.mycompany.local bash -c "evoke seed follower conjur-follower.mycompany.local > /opt/cyberark/dap/seeds/follower-seed.tar"')
+        system('docker-compose exec conjur-follower-1.mycompany.local bash -c "evoke unpack seed /opt/cyberark/dap/seeds/follower-seed.tar && evoke configure follower"')
+
+        # Start Load Balancer
+        system('docker-compose up -d --no-deps conjur-follower.mycompany.local')
+      end
+
+      def reset_environment
+        system('bin/dap --stop')
+      end
+
+      def import_custom_certificates
+        system('bin/dap --import-custom-certificates')
+      end
+
+      def provision_standbys(version:)
+        system("bin/dap --provision-standbys --version #{version}")
+      end
+
+      def enable_autofailover
+        system('bin/dap --enable-auto-failover')
+      end
+
+      def trigger_auto_failover
+        system('bin/dap --trigger-failover')
+      end
+
+      # Find the current master.  This is neccesary after a failover event.
+      def current_master
+        http = Net::HTTP.new('conjur-master.mycompany.local', 443)
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+        response = http.request(Net::HTTP::Get.new('/info'))
+
+        return nil unless response.is_a?(Net::HTTPSuccess)
+
+        conjur_info = JSON.parse(response.body)['configuration']['conjur']
+
+        if conjur_info.key?('cluster_master')
+          return conjur_info['cluster_master']
+        end
+
+        'conjur-master-1.mycompany.local'
+      end
+
+      def last_audit_event
+        last_audit = `docker-compose exec #{current_master} bash -c "tail -n 1 /var/log/conjur/audit.json"`
+
+        return JSON.parse(last_audit) unless last_audit.nil?
+      end
+
+      def upgrade_master(version:)
+        system("bin/dap --upgrade-master #{version}")
+      end
+    end
+  end
+end

--- a/ci/providers/docker_compose.rb
+++ b/ci/providers/docker_compose.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './ci/providers/interface'
+require './ci/providers/provider_interface'
 
 require 'json'
 require 'net/https'
@@ -14,7 +14,11 @@ module CI
     #
     # The DockerCompose class implements the public methods for the generic
     # CI::Providers::Interface using Docker Compose.
-    class DockerCompose < Interface
+    class DockerCompose < ProviderInterface
+
+      def initialize(logger:)
+        @logger = logger
+      end
 
       def provision_master(version:, with_load_balancer: true)
         system('cp files/haproxy/master/single/haproxy.cfg files/haproxy/master/haproxy.cfg')
@@ -68,7 +72,7 @@ module CI
         end
       end
 
-      def wait_for_failover_to_complete(sleep_for: 10)
+      def wait_for_healthy_master(sleep_for: 10)
         sleep(5)
         loop do
           begin

--- a/ci/providers/interface.rb
+++ b/ci/providers/interface.rb
@@ -25,6 +25,8 @@ module CI
 
       def trigger_auto_failover; end
 
+      def wait_for_failover_to_complete; end
+
       def last_audit_event; end
 
       def upgrade_master(version:); end

--- a/ci/providers/interface.rb
+++ b/ci/providers/interface.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module CI
+  module Providers
+    # This class implements the minimal set of methods a Provider must implement
+    # to ensure scenarios can be run.
+    class Interface
+      def master_api; end
+
+      def follower_api; end
+
+      def provision_master(version:, with_load_balancer: true); end
+
+      def provision_follower(version:, with_load_balancer: true); end
+
+      def reset_environment; end
+
+      def import_custom_certificates; end
+
+      def teardown; end
+
+      def provision_standbys(version:); end
+
+      def enable_autofailover; end
+
+      def trigger_auto_failover; end
+
+      def last_audit_event; end
+
+      def upgrade_master(version:); end
+    end
+  end
+end

--- a/ci/providers/provider_interface.rb
+++ b/ci/providers/provider_interface.rb
@@ -4,12 +4,12 @@ module CI
   module Providers
     # This class implements the minimal set of methods a Provider must implement
     # to ensure scenarios can be run.
-    class Interface
-      def master_api; end
+    class ProviderInterface
+      # def master_api; end
+      #
+      # def follower_api; end
 
-      def follower_api; end
-
-      def provision_master(version:, with_load_balancer: true); end
+      def provision_master(version:, with_load_balancer: true); raise 'method not implemen' end
 
       def provision_follower(version:, with_load_balancer: true); end
 
@@ -25,7 +25,7 @@ module CI
 
       def trigger_auto_failover; end
 
-      def wait_for_failover_to_complete; end
+      def wait_for_healthy_master; end
 
       def last_audit_event; end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,8 +163,4 @@ volumes:
 
 networks:
   dap_net:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 12.16.23.0/27
+    external: true

--- a/features/cluster.feature
+++ b/features/cluster.feature
@@ -9,7 +9,6 @@ Scenario: I deploy a cluster for a non-production environments
     And when I check the master audit log, I see the audit event
 
 Scenario: I deploy a cluster for a production environment
-  Given skip
   Given I deploy a DAP master with a load balancer
     And I configure the master with custom certificates
     And I deploy two standbys
@@ -26,7 +25,6 @@ Scenario: I deploy a cluster for a production environment
     And when I check the master audit log, I see the audit event
 
 Scenario Outline: I can upgrade a cluster from one version to another
-  Given skip
   Given I deploy a DAP master with version <release>
     And I deploy one follower with version <release>
     And I load a variable and value

--- a/features/cluster.feature
+++ b/features/cluster.feature
@@ -1,38 +1,41 @@
-Feature: A DAP cluster can be deployed
+Feature: A DAP cluster is deployed in a variety of configurations
 
-Scenario: A cluster is deployed for non-production environments
-  Given a DAP master is deployed
-    And one follower is deployed
-    And a variable and value are loaded
-  When a user requests the variable value
-  Then the variable value is returned
-    And the audit event is present on the master
+Scenario: I deploy a cluster for a non-production environments
+  Given I deploy a DAP master
+    And I deploy one follower
+    And I load a variable and value
+  When I request the variable value through the API
+  Then I get the variable value
+    And when I check the master audit log, I see the audit event
 
-Scenario: A cluster is deployed for production environments
-  Given a DAP master is deployed with a load balancer
-    And configured with custom certificates
-    And two standbys are deployed
-    And configured as an auto-failover cluster
-    And one follower is deployed with a load balancer
-    And a variable and value are loaded
-  When a user requests the variable value
-  Then the variable value is returned
-    And the audit event is present on the master
-  When a failover event is triggered
-    And the variable value is updated
-    And a user requests the variable value
-  Then the variable value is returned
-    And the audit event is present on the master
+Scenario: I deploy a cluster for a production environment
+  Given skip
+  Given I deploy a DAP master with a load balancer
+    And I configure the master with custom certificates
+    And I deploy two standbys
+    And I configured the master and standby as an auto-failover cluster
+    And I deploy a follower with a load balancer
+    And I load a variable and value
+  When I request the variable value through the API
+  Then I get the variable value
+    And when I check the master audit log, I see the audit event
+  When I trigger a failover event
+    And I update the variable value
+    And I request the variable value through the API
+  Then I get the variable value
+    And when I check the master audit log, I see the audit event
 
-Scenario Outline: A cluster can be upgraded from one version to another
-  Given a DAP master is deployed with version <release>
-    And one follower is deployed with version <release>
-    And a variable and value are loaded
-  When the master is upgraded to the current version
-    And the follower is upgraded to the current version
-    And a user requests the variable value
-  Then the variable value is returned
-    And the audit event is present on the master
+Scenario Outline: I can upgrade a cluster from one version to another
+  Given skip
+  Given I deploy a DAP master with version <release>
+    And I deploy one follower with version <release>
+    And I load a variable and value
+  When I upgrade the master to the current version
+    And I upgrade the follower to the current version
+    And I request the variable value through the API
+  Then I get the variable value
+    And when I check the master audit log, I see the audit event
+
   Examples: DAP Releases
     | release |
     | 11.6.0  |

--- a/features/cluster.feature
+++ b/features/cluster.feature
@@ -24,9 +24,7 @@ Scenario: A cluster is deployed for production environments
   Then the variable value is returned
     And the audit event is present on the master
 
-
-Scenario: A cluster can be upgraded from one version to another
-Scenario Outline: DAP Releases
+Scenario Outline: A cluster can be upgraded from one version to another
   Given a DAP master is deployed with version <release>
     And one follower is deployed with version <release>
     And a variable and value are loaded

--- a/features/cluster.feature
+++ b/features/cluster.feature
@@ -1,0 +1,41 @@
+Feature: A DAP cluster can be deployed
+
+Scenario: A cluster is deployed for non-production environments
+  Given a DAP master is deployed
+    And one follower is deployed
+    And a variable and value are loaded
+  When a user requests the variable value
+  Then the variable value is returned
+    And the audit event is present on the master
+
+Scenario: A cluster is deployed for production environments
+  Given a DAP master is deployed with a load balancer
+    And configured with custom certificates
+    And two standbys are deployed
+    And configured as an auto-failover cluster
+    And one follower is deployed with a load balancer
+    And a variable and value are loaded
+  When a user requests the variable value
+  Then the variable value is returned
+    And the audit event is present on the master
+  When a failover event is triggered
+    And the variable value is updated
+    And a user requests the variable value
+  Then the variable value is returned
+    And the audit event is present on the master
+
+
+Scenario: A cluster can be upgraded from one version to another
+Scenario Outline: DAP Releases
+  Given a DAP master is deployed with version <release>
+    And one follower is deployed with version <release>
+    And a variable and value are loaded
+  When the master is upgraded to the current version
+    And the follower is upgraded to the current version
+    And a user requests the variable value
+  Then the variable value is returned
+    And the audit event is present on the master
+  Examples: DAP Releases
+    | release |
+    | 11.6.0  |
+    | 11.7.0  |

--- a/features/step_definitions/dap_configuration.rb
+++ b/features/step_definitions/dap_configuration.rb
@@ -2,51 +2,58 @@
 
 
 # Setup tasks
-Given('a DAP master is deployed') do
-  @provider.provision_master(version: @current_version)
+Given('I deploy a DAP master') do
+  @provider.provision_master(version: CURRENT_VERSION)
 end
 
-Given('one follower is deployed') do
-  @provider.provision_follower(version: @current_version)
+Given('I deploy one follower') do
+  @provider.provision_follower(version: CURRENT_VERSION)
 end
 
-Given('a DAP master is deployed with a load balancer') do
-  @provider.provision_master(version: @current_version, with_load_balancer: true)
+Given('I deploy a DAP master with a load balancer') do
+  @provider.provision_master(version: CURRENT_VERSION, with_load_balancer: true)
 end
 
-Given('configured with custom certificates') do
-  @provider.import_custom_certificates
+Given('I configure the master with custom certificates') do |word|
+  @provider.import_custom_certificates if word.match?('with')
 end
 
-Given('two standbys are deployed') do
-  @provider.provision_standbys(version: @current_version)
+Given('I deploy two standbys') do
+  @provider.provision_standbys(version: CURRENT_VERSION)
 end
 
-Given('configured as an auto-failover cluster') do
-  @provider.enable_autofailover
+Given('I configured the master and standby as an auto-failover cluster') do |word|
+  @provider.enable_autofailover if word.match?('with')
 end
 
-Given('one follower is deployed with a load balancer') do
-  @provider.provision_follower(version: @current_version, with_load_balancer: true)
+Given('I deploy a follower with a load balancer') do
+  @provider.provision_follower(
+    version: CURRENT_VERSION,
+    with_load_balancer: true
+  )
 end
 
-When('a failover event is triggered') do
+When('I trigger a failover event') do
   @provider.trigger_auto_failover
-  @provider.wait_for_failover_to_complete
+  @provider.wait_for_healthy_master
 end
 
-Given('a DAP master is deployed with version {int}.{int}.{int}') do |int1, int2, int3|
+Given('I deploy a DAP master with version {int}.{int}.{int}') do |int1, int2, int3|
   @provider.provision_master(version: "#{int1}.#{int2}.#{int3}")
 end
 
-Given('one follower is deployed with version {int}.{int}.{int}') do |int1, int2, int3|
+Given('I deploy one follower with version {int}.{int}.{int}') do |int1, int2, int3|
   @provider.provision_follower(version: "#{int1}.#{int2}.#{int3}")
 end
 
-When('the master is upgraded to the current version') do
-  @provider.upgrade_master(version: @current_version)
+When('I upgrade the master to the current version') do
+  @provider.upgrade_master(version: CURRENT_VERSION)
 end
 
-When('the follower is upgraded to the current version') do
-  @provider.provision_follower(version: @current_version)
+When('I upgrade the follower to the current version') do
+  @provider.provision_follower(version: CURRENT_VERSION)
 end
+
+# Given('configured with {word} master key encryption') do |mke|
+#   pending # Write code here that turns the phrase above into concrete actions
+# end

--- a/features/step_definitions/dap_configuration.rb
+++ b/features/step_definitions/dap_configuration.rb
@@ -32,7 +32,7 @@ end
 
 When('a failover event is triggered') do
   @provider.trigger_auto_failover
-  sleep(90)
+  @provider.wait_for_failover_to_complete
 end
 
 Given('a DAP master is deployed with version {int}.{int}.{int}') do |int1, int2, int3|

--- a/features/step_definitions/dap_configuration.rb
+++ b/features/step_definitions/dap_configuration.rb
@@ -14,16 +14,16 @@ Given('I deploy a DAP master with a load balancer') do
   @provider.provision_master(version: CURRENT_VERSION, with_load_balancer: true)
 end
 
-Given('I configure the master with custom certificates') do |word|
-  @provider.import_custom_certificates if word.match?('with')
+Given('I configure the master with custom certificates') do
+  @provider.import_custom_certificates
 end
 
 Given('I deploy two standbys') do
   @provider.provision_standbys(version: CURRENT_VERSION)
 end
 
-Given('I configured the master and standby as an auto-failover cluster') do |word|
-  @provider.enable_autofailover if word.match?('with')
+Given('I configured the master and standby as an auto-failover cluster') do
+  @provider.enable_autofailover
 end
 
 Given('I deploy a follower with a load balancer') do

--- a/features/step_definitions/dap_configuration.rb
+++ b/features/step_definitions/dap_configuration.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+
+# Setup tasks
+Given('a DAP master is deployed') do
+  @provider.provision_master(version: @current_version)
+end
+
+Given('one follower is deployed') do
+  @provider.provision_follower(version: @current_version)
+end
+
+Given('a DAP master is deployed with a load balancer') do
+  @provider.provision_master(version: @current_version, with_load_balancer: true)
+end
+
+Given('configured with custom certificates') do
+  @provider.import_custom_certificates
+end
+
+Given('two standbys are deployed') do
+  @provider.provision_standbys(version: @current_version)
+end
+
+Given('configured as an auto-failover cluster') do
+  @provider.enable_autofailover
+end
+
+Given('one follower is deployed with a load balancer') do
+  @provider.provision_follower(version: @current_version, with_load_balancer: true)
+end
+
+When('a failover event is triggered') do
+  @provider.trigger_auto_failover
+  sleep(90)
+end
+
+Given('a DAP master is deployed with version {int}.{int}.{int}') do |int1, int2, int3|
+  @provider.provision_master(version: "#{int1}.#{int2}.#{int3}")
+end
+
+Given('one follower is deployed with version {int}.{int}.{int}') do |int1, int2, int3|
+  @provider.provision_follower(version: "#{int1}.#{int2}.#{int3}")
+end
+
+When('the master is upgraded to the current version') do
+  @provider.upgrade_master(version: @current_version)
+end
+
+When('the follower is upgraded to the current version') do
+  @provider.provision_follower(version: @current_version)
+end

--- a/features/step_definitions/dap_validation.rb
+++ b/features/step_definitions/dap_validation.rb
@@ -14,7 +14,7 @@ end
 Then('the variable value is returned') do
   expect(
     @variable_request['demo:variable:staging/my-app-1/postgres-database/password']
-  ).to eq('secret-p@ssword')
+  ).to eq('secret-p@ssword-staging-my-app-1')
 end
 
 Then('the audit event is present on the master') do

--- a/features/step_definitions/dap_validation.rb
+++ b/features/step_definitions/dap_validation.rb
@@ -1,23 +1,21 @@
 # frozen_string_literal: true
 
-# require 'json'
-
 # Validation tasks
-Given('a variable and value are loaded') do
+Given('I load a variable and value') do
   system('bin/api --load-policy-and-values')
 end
 
-When('a user requests the variable value') do
+When('I request the variable value through the API') do
   @variable_request = JSON.parse(`bin/api --fetch-secrets`)
 end
 
-Then('the variable value is returned') do
+Then('I get the variable value') do
   expect(
     @variable_request['demo:variable:staging/my-app-1/postgres-database/password']
   ).to eq('secret-p@ssword-staging-my-app-1')
 end
 
-Then('the audit event is present on the master') do
+Then('when I check the master audit log, I see the audit event') do
   response = @provider.last_audit_event
   expect(response['subject@43868']['resource']).to eq(
     'demo:variable:staging/my-app-1/postgres-database/port'
@@ -26,6 +24,6 @@ Then('the audit event is present on the master') do
   expect(response['action@43868']['result']).to eq('success')
 end
 
-When('the variable value is updated') do
+When('I update the variable value') do
   system('bin/api --set-secrets')
 end

--- a/features/step_definitions/dap_validation.rb
+++ b/features/step_definitions/dap_validation.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# require 'json'
+
+# Validation tasks
+Given('a variable and value are loaded') do
+  system('bin/api --load-policy-and-values')
+end
+
+When('a user requests the variable value') do
+  @variable_request = JSON.parse(`bin/api --fetch-secrets`)
+end
+
+Then('the variable value is returned') do
+  expect(
+    @variable_request['demo:variable:staging/my-app-1/postgres-database/password']
+  ).to eq('secret-p@ssword')
+end
+
+Then('the audit event is present on the master') do
+  response = @provider.last_audit_event
+  expect(response['subject@43868']['resource']).to eq(
+    'demo:variable:staging/my-app-1/postgres-database/port'
+  )
+  expect(response['auth@43868']['user']).to eq('demo:user:admin')
+  expect(response['action@43868']['result']).to eq('success')
+end
+
+When('the variable value is updated') do
+  system('bin/api --set-secrets')
+end

--- a/features/step_definitions/world.rb
+++ b/features/step_definitions/world.rb
@@ -1,13 +1,34 @@
 # frozen_string_literal: true
 
-Before do
-  @current_version = '5.12.4'
-  case ENV['PROVIDER']
-  when 'docker'
-    @provider = CI::Providers::DockerCompose.new
-  else
-    raise "No Provider available for #{ENV['PROVIDER']}"
+require 'logger'
+require './ci/providers/docker_compose'
+
+CURRENT_VERSION = '12.0.0'
+
+def logger
+  @logger ||= begin
+    level = ENV['LOG_LEVEL'] || 'INFO'
+    log_level = Kernel.const_get("Logger::#{level.upcase}")
+    logger = Logger.new(STDOUT)
+    logger.level = log_level
+    logger
   end
+end
+
+def provider(type:)
+  @provider_cache ||= {}
+  @provider_cache[type] ||= begin
+    case type
+    when 'docker'
+      CI::Providers::DockerCompose.new(logger: logger)
+    else
+      raise "No Provider available for #{ENV['PROVIDER']}"
+    end
+  end
+end
+
+Before do
+  @provider = provider(type: ENV['PROVIDER'])
 end
 
 After do

--- a/features/step_definitions/world.rb
+++ b/features/step_definitions/world.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Before do
+  @current_version = '5.12.4'
+  case ENV['PROVIDER']
+  when 'docker'
+    @provider = CI::Providers::DockerCompose.new
+  else
+    raise "No Provider available for #{ENV['PROVIDER']}"
+  end
+end
+
+After do
+  @provider.reset_environment
+end
+
+Given 'skip' do
+  skip_this_scenario
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-require './ci/providers/docker_compose'
-
 at_exit do
-  case ENV['PROVIDER']
-  when 'docker'
-    provider = CI::Providers::DockerCompose.new
-  else
-    raise "No Provider available for #{ENV['PROVIDER']}"
-  end
-  provider.teardown
+  provider(type: ENV['PROVIDER']).teardown
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require './ci/providers/docker_compose'
+
+at_exit do
+  case ENV['PROVIDER']
+  when 'docker'
+    provider = CI::Providers::DockerCompose.new
+  else
+    raise "No Provider available for #{ENV['PROVIDER']}"
+  end
+  provider.teardown
+end


### PR DESCRIPTION
#### What does this PR do? Is there any background context you want to provide?
This PR adds a series of end-to-end tests for the DAP appliance.  This PR intentionally leaves Jenkins driven testing out.  I'll be adding this in a future PR as it will take some additional work to understand when these tests should be run.

#### What ticket does this PR close?
Connects to [aam-architecture#8](https://github.com/conjurinc/aam-architecture/issues/8)

#### Where should the reviewer start? How should this functionality be validated?
Top-down, I'd recommend reviewing:
- Feature - `features/cluster.feature`
- Steps - `features/step_definitions/dap_configuration.rb`, `features/step_definitions/dap_validation.rb`
- Provider - `ci/providers/docker_compose.rb`

#### Reviewers
- @jtuttle, @micahlee - I'd love feedback on the approach and areas of improvement
- @alexkalish - I'd love feedback on the scope of the tests 