### PR TITLE
Add DAP Intro Option for Node Certificate Rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ files/haproxy/master/haproxy.cfg
 
 # Generated Certificates
 **/certificates/ca-chain.pem
-**/certificates/dap-follower.pem
-**/certificates/dap-follower-key.pem
-**/certificates/dap-master.pem
-**/certificates/dap-master-key.pem
+**/certificates/dap_follower/
+**/certificates/dap_master/
+**/certificates/intermediate_ca/
+**/certificates/root_ca/

--- a/artifacts/api-client/api-script
+++ b/artifacts/api-client/api-script
@@ -59,6 +59,7 @@ load_policy() {
   local method="${3:-POST}"
   local token=$(authenticate_user $USER $PASSWORD $master_url)
   curl --header "Authorization: Token token=\"$token\"" \
+        --write-out "\n" \
         --insecure \
         --request "$method" \
         --data "$(cat $policy)" \
@@ -118,6 +119,7 @@ fetch_secrets() {
   local variables="$1"
   local token=$(authenticate_user $USER $PASSWORD $URL)
   curl --header "Authorization: Token token=\"$token\"" \
+        --write-out "\n" \
         --insecure \
         --request GET \
         "$master_url/secrets?variable_ids=$variables"
@@ -136,6 +138,7 @@ load_policy_and_set_variables() {
 view_policy_members() {
   local token=$(authenticate_user $USER $PASSWORD $URL)
   curl --header "Authorization: Token token=\"$token\"" \
+        --write-out "\n" \
         --insecure \
         --request GET \
         "$master_url/roles/demo/policy/production?members"
@@ -144,6 +147,7 @@ view_policy_members() {
 view_roles() {
   local token=$(authenticate_user $USER $PASSWORD $URL)
   curl --header "Authorization: Token token=\"$token\"" \
+        --write-out "\n" \
         --insecure \
         --request GET \
         "$master_url/resources/demo" | jq .

--- a/artifacts/api-client/api-script
+++ b/artifacts/api-client/api-script
@@ -1,6 +1,6 @@
 #!/bin/ash -e
 
-function _print_help() {
+_print_help() {
   cat << EOF
 
 A tool which uses the DAP API to perform various tasks.
@@ -24,7 +24,7 @@ EOF
   exit
 }
 
-function retrieve_authentication_token() {
+retrieve_authentication_token() {
   local user="$1"
   # Allow hosts to be used instead of just users
   user=$(echo "$user" | sed -e "s/\//%2F/g")
@@ -40,7 +40,7 @@ function retrieve_authentication_token() {
   echo "$token"
 }
 
-function authenticate_user() {
+authenticate_user() {
   local user="$1"
   local password="$2"
   local url="${3:-$URL}"
@@ -53,7 +53,7 @@ function authenticate_user() {
   echo "$token"
 }
 
-function load_policy() {
+load_policy() {
   local namespace="$1"
   local policy="$2"
   local method="${3:-POST}"
@@ -65,7 +65,7 @@ function load_policy() {
      "$master_url/policies/demo/policy/$namespace"
 }
 
-function set_variable() {
+set_variable() {
   local variable="$1"
   local value="$2"
   local token=$(authenticate_user $USER $PASSWORD $master_url)
@@ -76,7 +76,7 @@ function set_variable() {
         "$master_url/secrets/demo/variable/$variable"
 }
 
-function load_default_policy {
+load_default_policy() {
   local environments='staging production'
   local numbers='1 2 3 4 5 6'
 
@@ -100,7 +100,7 @@ delete_policy() {
   load_policy 'delete_branch/first-level' 'policy/delete_policy/delete.yml' 'PATCH'
 }
 
-function load_default_values {
+load_default_values() {
   local environments='staging production'
   local numbers='1 2 3 4 5 6'
 
@@ -114,7 +114,7 @@ function load_default_values {
   done
 }
 
-function fetch_secrets {
+fetch_secrets() {
   local variables="$1"
   local token=$(authenticate_user $USER $PASSWORD $URL)
   curl --header "Authorization: Token token=\"$token\"" \
@@ -123,17 +123,17 @@ function fetch_secrets {
         "$master_url/secrets?variable_ids=$variables"
 }
 
-function retrieve_variables {
+retrieve_variables() {
   secrets="demo:variable:staging/my-app-1/postgres-database/url,demo:variable:staging/my-app-1/postgres-database/port,demo:variable:staging/my-app-1/postgres-database/username,demo:variable:staging/my-app-1/postgres-database/password"
   fetch_secrets $secrets
 }
 
-function load_policy_and_set_variables {
+load_policy_and_set_variables() {
   load_default_policy
   load_default_values
 }
 
-function view_policy_members {
+view_policy_members() {
   local token=$(authenticate_user $USER $PASSWORD $URL)
   curl --header "Authorization: Token token=\"$token\"" \
         --insecure \
@@ -141,7 +141,7 @@ function view_policy_members {
         "$master_url/roles/demo/policy/production?members"
 }
 
-function view_roles {
+view_roles() {
   local token=$(authenticate_user $USER $PASSWORD $URL)
   curl --header "Authorization: Token token=\"$token\"" \
         --insecure \
@@ -149,14 +149,14 @@ function view_roles {
         "$master_url/resources/demo" | jq .
 }
 
-function rotate_api_key {
+rotate_api_key() {
   curl --header "Authorization: Token token=\"$token\"" \
         --insecure \
         --request GET \
         "$master_url/resources/demo"
 }
 
-function enable_seed_service {
+enable_seed_service() {
   load_policy 'root' 'policy/seed-service/default.yml'
   load_policy 'conjur' 'policy/seed-service/seed.yml'
 }

--- a/artifacts/certificate-generator/Dockerfile
+++ b/artifacts/certificate-generator/Dockerfile
@@ -17,4 +17,4 @@ RUN mkdir -p /src
 COPY . /src
 WORKDIR /src
 
-ENTRYPOINT "./generate-certs-script"
+ENTRYPOINT [ "/src/generate-certs-script" ]

--- a/artifacts/certificate-generator/generate-certs-script
+++ b/artifacts/certificate-generator/generate-certs-script
@@ -10,6 +10,25 @@ intermediate_destination="$certificate_path/intermediate_ca/intermediate"
 master_destination="$certificate_path/dap_master/dap-master"
 follower_destination="$certificate_path/dap_follower/dap-follower"
 
+GENERATE_CA=true
+GENERATE_SERVER=true
+FORCE=false
+
+main() {
+  echo "$@"
+  while true ; do
+    case "$1" in
+      --rotate-server ) GENERATE_CA=false; shift ;;
+      --force ) FORCE=true; shift ;;
+      -h | --help ) print_help ; shift ;;
+      * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
+    esac
+  done
+
+  create_folders
+  generate_certificates
+}
+
 print_help() {
   cat << EOF
 
@@ -18,21 +37,10 @@ Generates a Root, Intermediate, DAP Master and Follower certificates
 Usage: bin/generate-certs [options]
 
     -h, --help        Shows this help message.
+    --rotate-server   Only generate new server certificates
+    --force           Generate certificates even if they already exist
 
 EOF
-  exit
-}
-
-copy_to_demo() {
-  certificate_destination="/src/dap_certificates"
-  cat $certificate_path/root_ca/ca.pem \
-    $certificate_path/intermediate_ca/intermediate.pem > \
-      $certificate_destination/ca-chain.pem
-  cp $master_destination-key.pem $certificate_destination/
-  cp $master_destination.pem $certificate_destination/
-  cp $follower_destination-key.pem $certificate_destination/
-  cp $follower_destination.pem $certificate_destination/
-  echo "Certificates copied to 'system/configuration/certificates'"
   exit
 }
 
@@ -44,52 +52,54 @@ create_folders() {
 }
 
 generate_certificates() {
-  # Generate Root Certificate if it does not exist
-  if [ ! -f "$root_destination.pem" ]; then
-    cfssl gencert -initca "$config_path/root_ca.json" | \
-    cfssljson -bare $root_destination
-  fi
+  if [ "$GENERATE_CA" = true ]; then
+    # Generate Root Certificate if it does not exist
+    if [ ! -f "$root_destination.pem" ] || [ "$FORCE" = true ]; then
+      cfssl gencert -initca "$config_path/root_ca.json" | \
+      cfssljson -bare $root_destination
+    fi
 
-  # Generate and sign intermediate certificate if it does not exist
-  if [ ! -f "$intermediate_destination.pem" ]; then
-    # Generate Intermediate Certificate
-    cfssl gencert -initca $config_path/intermediate_ca.json | \
-    cfssljson -bare $intermediate_destination
+    # Generate and sign intermediate certificate if it does not exist
+    if [ ! -f "$intermediate_destination.pem" ] || [ "$FORCE" = true ]; then
+      # Generate Intermediate Certificate
+      cfssl gencert -initca $config_path/intermediate_ca.json | \
+      cfssljson -bare $intermediate_destination
 
-    # Sign Intermediate with Root
-    cfssl sign \
-      -ca $root_destination.pem \
-      -ca-key $root_destination-key.pem \
-      -config $config_path/cfssl.conf \
-      -profile intermediate_ca \
-      $intermediate_destination.csr | cfssljson -bare $intermediate_destination
+      # Sign Intermediate with Root
+      cfssl sign \
+        -ca $root_destination.pem \
+        -ca-key $root_destination-key.pem \
+        -config $config_path/cfssl.conf \
+        -profile intermediate_ca \
+        $intermediate_destination.csr | cfssljson -bare $intermediate_destination
+    fi
+
+    cat $certificate_path/root_ca/ca.pem \
+      $certificate_path/intermediate_ca/intermediate.pem > \
+      $certificate_path/ca-chain.pem
   fi
 
   # Generate and sign master certificate w/ intermediate
-  if [ ! -f "$master_destination.pem" ]; then
-    cfssl gencert \
-      -ca $intermediate_destination.pem \
-      -ca-key $intermediate_destination-key.pem \
-      -config $config_path/cfssl.conf \
-      -profile=peer \
-      $config_path/dap-master.json | cfssljson -bare $master_destination
-  fi
+  if [ "$GENERATE_SERVER" = true ]; then
+    if [ ! -f "$master_destination.pem" ] || [ "$FORCE" = true ]; then
+      cfssl gencert \
+        -ca $intermediate_destination.pem \
+        -ca-key $intermediate_destination-key.pem \
+        -config $config_path/cfssl.conf \
+        -profile=peer \
+        $config_path/dap-master.json | cfssljson -bare $master_destination
+    fi
 
-  # Generate and sign follower certificate w/ intermediate
-  if [ ! -f "$follower_destination.pem" ]; then
-    cfssl gencert \
-      -ca $intermediate_destination.pem \
-      -ca-key $intermediate_destination-key.pem \
-      -config $config_path/cfssl.conf \
-      -profile=peer \
-      $config_path/dap-follower.json | cfssljson -bare $follower_destination
+    # Generate and sign follower certificate w/ intermediate
+    if [ ! -f "$follower_destination.pem" ] || [ "$FORCE" = true ]; then
+      cfssl gencert \
+        -ca $intermediate_destination.pem \
+        -ca-key $intermediate_destination-key.pem \
+        -config $config_path/cfssl.conf \
+        -profile=peer \
+        $config_path/dap-follower.json | cfssljson -bare $follower_destination
+    fi
   fi
 }
 
-main() {
-  create_folders
-  generate_certificates
-  copy_to_demo
-}
-
-main
+main "$@"

--- a/artifacts/certificate-generator/generate-certs-script
+++ b/artifacts/certificate-generator/generate-certs-script
@@ -74,8 +74,8 @@ generate_certificates() {
         $intermediate_destination.csr | cfssljson -bare $intermediate_destination
     fi
 
-    cat $certificate_path/root_ca/ca.pem \
-      $certificate_path/intermediate_ca/intermediate.pem > \
+    cat $certificate_path/intermediate_ca/intermediate.pem \
+      $certificate_path/root_ca/ca.pem > \
       $certificate_path/ca-chain.pem
   fi
 

--- a/artifacts/certificate-generator/generate-certs-script
+++ b/artifacts/certificate-generator/generate-certs-script
@@ -81,25 +81,67 @@ generate_certificates() {
 
   # Generate and sign master certificate w/ intermediate
   if [ "$GENERATE_SERVER" = true ]; then
+    if [ ! -f "$master_destination-key.pem" ]; then
+      generate_master_key      
+    fi
+
     if [ ! -f "$master_destination.pem" ] || [ "$FORCE" = true ]; then
-      cfssl gencert \
-        -ca $intermediate_destination.pem \
-        -ca-key $intermediate_destination-key.pem \
-        -config $config_path/cfssl.conf \
-        -profile=peer \
-        $config_path/dap-master.json | cfssljson -bare $master_destination
+      generate_master_csr
+      issue_master_certificate
+    fi
+    
+    if [ ! -f "$follower_destination-key.pem" ]; then
+      generate_follower_key      
     fi
 
     # Generate and sign follower certificate w/ intermediate
     if [ ! -f "$follower_destination.pem" ] || [ "$FORCE" = true ]; then
-      cfssl gencert \
-        -ca $intermediate_destination.pem \
-        -ca-key $intermediate_destination-key.pem \
-        -config $config_path/cfssl.conf \
-        -profile=peer \
-        $config_path/dap-follower.json | cfssljson -bare $follower_destination
+      generate_follower_csr
+      issue_follower_certificate
     fi
   fi
+}
+
+generate_master_key() {
+  cfssl genkey \
+    -config $config_path/cfssl.conf \
+    $config_path/dap-master.json | cfssljson -bare $master_destination
+}
+
+generate_master_csr() {
+  cfssl gencsr \
+    -key "$master_destination-key.pem" \
+    $config_path/dap-master.json | cfssljson -bare $master_destination
+}
+
+issue_master_certificate() {
+  cfssl sign \
+    -ca $intermediate_destination.pem \
+    -ca-key $intermediate_destination-key.pem \
+    -config $config_path/cfssl.conf \
+    -profile=peer \
+    $master_destination.csr | cfssljson -bare $master_destination
+}
+
+generate_follower_key() {
+  cfssl genkey \
+    -config $config_path/cfssl.conf \
+    $config_path/dap-follower.json | cfssljson -bare $follower_destination
+}
+
+generate_follower_csr() {
+  cfssl gencsr \
+    -key "$follower_destination-key.pem" \
+    $config_path/dap-follower.json | cfssljson -bare $follower_destination
+}
+
+issue_follower_certificate() {
+  cfssl sign \
+    -ca $intermediate_destination.pem \
+    -ca-key $intermediate_destination-key.pem \
+    -config $config_path/cfssl.conf \
+    -profile=peer \
+    $follower_destination.csr | cfssljson -bare $follower_destination
 }
 
 main "$@"

--- a/bin/dap
+++ b/bin/dap
@@ -198,7 +198,7 @@ function _disable_autofailover {
 }
 
 function _enable_autofailover {
-  autofailover=$(curl -k https://conjur-master.mycompany.local/info | jq -r .configuration.conjur.cluster_name)
+  autofailover=$(curl -k https://localhost/info | jq -r .configuration.conjur.cluster_name)
 
   if [ "$autofailover" = 'production' ]; then
     _run conjur-master-2.mycompany.local "evoke cluster enroll --reenroll --cluster-machine-name conjur-master-2.mycompany.local --master-name conjur-master-1.mycompany.local production"
@@ -233,7 +233,7 @@ function _stop_and_rename {
 function _upgrade_via_backup_restore {
   upgrade_to="$1"
 
-  autofailover=$(curl -k https://conjur-master.mycompany.local/info | jq -r .configuration.conjur.cluster_name)
+  autofailover=$(curl -k https://localhost/info | jq -r .configuration.conjur.cluster_name)
 
   if [ "$autofailover" = 'production' ]; then
     _disable_autofailover
@@ -299,9 +299,73 @@ function _import_certificates {
   _run conjur-master-1.mycompany.local \
     "evoke ca import --force --root $cert_path/ca-chain.pem"
   _run conjur-master-1.mycompany.local \
-    "evoke ca import --force --key $cert_path/dap-master-key.pem --set $cert_path/dap-master.pem"
+    "evoke ca import --force --key $cert_path/dap_master/dap-master-key.pem --set $cert_path/dap_master/dap-master.pem"
   _run conjur-master-1.mycompany.local \
-    "evoke ca import --force --key $cert_path/dap-follower-key.pem $cert_path/dap-follower.pem"
+    "evoke ca import --force --key $cert_path/dap_follower/dap-follower-key.pem $cert_path/dap_follower/dap-follower.pem"
+}
+
+function _rotate_certificates {
+  bin/generate-certs --rotate-server --force
+
+  # Disable auto-failover while rotating the Master cluster certificates
+  # to prevent an unintended failover.
+  _pause_autofailover
+
+  # Import the new certificate into the active DAP Master
+  local cert_path='/opt/cyberark/dap/configuration/certificates'
+  _run conjur-master-1.mycompany.local \
+    "evoke ca import --force --key $cert_path/dap_master/dap-master-key.pem --set $cert_path/dap_master/dap-master.pem"
+  
+  # Import the new Follower certificate into the active DAP master so that it
+  # is available through the seed service
+  _run conjur-master-1.mycompany.local \
+    "evoke ca import --force --key $cert_path/dap_follower/dap-follower-key.pem $cert_path/dap_follower/dap-follower.pem"
+
+  # Import the new certificate into the DAP Standbys
+  if [[ $(docker ps --quiet --filter "name=conjur-master-2.mycompany.local") ]]; then
+    _run conjur-master-2.mycompany.local \
+      "evoke ca import --force --key $cert_path/dap_master/dap-master-key.pem --set $cert_path/dap_master/dap-master.pem"
+  
+    # Import the new Follower certificate into each DAP Standby so that it
+    # is available through the seed service if the Standby is promoted.
+    _run conjur-master-2.mycompany.local \
+      "evoke ca import --force --key $cert_path/dap_follower/dap-follower-key.pem $cert_path/dap_follower/dap-follower.pem"
+  fi
+  
+  if [[ $(docker ps --quiet --filter "name=conjur-master-3.mycompany.local") ]]; then
+    _run conjur-master-3.mycompany.local \
+      "evoke ca import --force --key $cert_path/dap_master/dap-master-key.pem --set $cert_path/dap_master/dap-master.pem"
+  
+    # Import the new Follower certificate into each DAP Standby so that it
+    # is available through the seed service if the Standby is promoted.
+    _run conjur-master-3.mycompany.local \
+      "evoke ca import --force --key $cert_path/dap_follower/dap-follower-key.pem $cert_path/dap_follower/dap-follower.pem"
+  fi
+
+  # Re-enable auto-failover for the Master cluster
+  _resume_autofailover
+
+  if [[ $(docker ps --quiet --filter "name=conjur-follower-1.mycompany.local") ]]; then
+    # Import the new certificate into each Follower
+    _run conjur-follower-1.mycompany.local \
+      "evoke ca import --force --key $cert_path/dap_follower/dap-follower-key.pem --set $cert_path/dap_follower/dap-follower.pem"
+  fi
+}
+
+function _pause_autofailover {
+  autofailover=$(curl -k https://localhost/info | jq -r .configuration.conjur.cluster_name)
+  if [ "$autofailover" = 'production' ]; then
+    _run conjur-master-2.mycompany.local "sv down cluster"
+    _run conjur-master-3.mycompany.local "sv down cluster"
+  fi
+}
+
+function _resume_autofailover {
+  autofailover=$(curl -k https://localhost/info | jq -r .configuration.conjur.cluster_name)
+  if [ "$autofailover" = 'production' ]; then
+    _run conjur-master-2.mycompany.local "sv up cluster"
+    _run conjur-master-3.mycompany.local "sv up cluster"
+  fi
 }
 
 function _wait_for_master {
@@ -353,6 +417,7 @@ while true ; do
     --provision-master ) CMD='_single_master' ; shift ;;
     --promote-standby ) CMD='_perform_promotion' ; shift ;;
     --import-custom-certificates ) CMD='_import_certificates' ; shift ;;
+    --rotate-custom-certificates ) CMD='_rotate_certificates' ; shift ;;
     --provision-standbys ) CMD='_setup_standbys' ; shift ;;
     --enable-auto-failover ) CMD='_enable_autofailover' ; shift ;;
     --provision-follower ) CMD='_setup_follower' ; shift ;;

--- a/bin/generate-certs
+++ b/bin/generate-certs
@@ -2,4 +2,4 @@
 
 export VERSION='5.0-stable'
 
-docker-compose run --no-deps --rm certificate-generator
+docker-compose run --no-deps --rm certificate-generator "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
     build:
       context: ./artifacts/certificate-generator
     volumes:
-      - ./system/configuration/certificates:/src/dap_certificates
+      - ./system/configuration/certificates:/src/certificates
 
 volumes:
   seeds:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "1999"
       - "5432"
     volumes:
+      - master-certs:/etc/ssl/certs
       - ./files/haproxy/master:/usr/local/etc/haproxy
 
   conjur-master-1.mycompany.local:
@@ -32,6 +33,7 @@ services:
         - "seccomp:unconfined"
     volumes:
       - seeds:/opt/cyberark/dap/seeds
+      - master-certs:/opt/conjur/etc/ssl/
       - ./system/backup:/opt/conjur/backup:Z
       - ./system/configuration:/opt/cyberark/dap/configuration:Z
       - ./system/logs/master-1:/var/log/conjur:Z
@@ -53,6 +55,7 @@ services:
         - "seccomp:unconfined"
     volumes:
       - seeds:/opt/cyberark/dap/seeds
+      - master-certs:/opt/conjur/etc/ssl/
       - ./system/backup:/opt/conjur/backup:Z
       - ./system/configuration:/opt/cyberark/dap/configuration:Z
       - ./system/logs/master-2:/var/log/conjur:Z
@@ -74,6 +77,7 @@ services:
         - "seccomp:unconfined"
     volumes:
       - seeds:/opt/cyberark/dap/seeds
+      - master-certs:/opt/conjur/etc/ssl/
       - ./system/backup:/opt/conjur/backup:Z
       - ./system/configuration:/opt/cyberark/dap/configuration:Z
       - ./system/logs/master-3:/var/log/conjur:Z
@@ -160,6 +164,7 @@ services:
 volumes:
   seeds:
   follower-certs:
+  master-certs:
 
 networks:
   dap_net:

--- a/files/haproxy/follower/haproxy.cfg
+++ b/files/haproxy/follower/haproxy.cfg
@@ -28,7 +28,7 @@ frontend www
 backend www-backend
   balance roundrobin
   option httpchk GET /health
-  server conjur-follower-1 conjur-follower-1.mycompany.local:443 check port 444 ssl ca-file /etc/ssl/certs/ca.pem
+  server conjur-follower-1 conjur-follower-1.mycompany.local:443 check port 443 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem ssl ca-file /etc/ssl/certs/ca.pem
 
 #
 # Enables HAProxy's UI for debugging

--- a/files/haproxy/master/multi-node/haproxy.cfg
+++ b/files/haproxy/master/multi-node/haproxy.cfg
@@ -45,9 +45,9 @@ backend www-backend
   mode tcp
   balance roundrobin
   option httpchk GET /health
-  server conjur-master-1 conjur-master-1.mycompany.local:443 check port 444
-  server conjur-master-2 conjur-master-2.mycompany.local:443 check port 444
-  server conjur-master-3 conjur-master-3.mycompany.local:443 check port 444
+  server conjur-master-1 conjur-master-1.mycompany.local:443 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem
+  server conjur-master-2 conjur-master-2.mycompany.local:443 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem
+  server conjur-master-3 conjur-master-3.mycompany.local:443 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem
 
 
 #
@@ -58,9 +58,9 @@ backend postgres-backend
   mode tcp
   balance roundrobin
   option httpchk GET /health
-  server conjur-master-1 conjur-master-1.mycompany.local:5432 check port 444
-  server conjur-master-2 conjur-master-2.mycompany.local:5432 check port 444
-  server conjur-master-3 conjur-master-3.mycompany.local:5432 check port 444
+  server conjur-master-1 conjur-master-1.mycompany.local:5432 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem
+  server conjur-master-2 conjur-master-2.mycompany.local:5432 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem
+  server conjur-master-3 conjur-master-3.mycompany.local:5432 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem
 
 #
 # Performs Layer 4 proxy
@@ -70,9 +70,9 @@ backend syslog-backend
   mode tcp
   balance roundrobin
   option httpchk GET /health
-  server conjur-master-1 conjur-master-1.mycompany.local:1999 check port 444
-  server conjur-master-2 conjur-master-2.mycompany.local:1999 check port 444
-  server conjur-master-3 conjur-master-3.mycompany.local:1999 check port 444
+  server conjur-master-1 conjur-master-1.mycompany.local:1999 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem
+  server conjur-master-2 conjur-master-2.mycompany.local:1999 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem
+  server conjur-master-3 conjur-master-3.mycompany.local:1999 check port 443 check-ssl ca-file /etc/ssl/certs/ca.pem
 
 #
 # Enables HAProxy's UI for debugging


### PR DESCRIPTION
This PR modifies DAP intro in a couple of ways:

* It updates the HAProxy config to support older versions of DAP by using the standard HTTPS port (443) for health checks, rather than rely on the newer HTTP health check on port 444.

* It adds a procedure flag to dap intro to rotate the node certificates called `--rotate-custom-certificates`. This allows for quickly testing certificate rotation for the Master, Standbys, and Follower in DAP Intro.

Closes #89

To try the new rotation function:

```
# Provision a Master
bin/dap --provision-master

# Import custom certificates
bin/dap --import-custom-certificates

# Provision Standbys
bin/dap --provision-standbys

# (Optional) Enable Auto-failover
bin/dap --enable-auto-failover

# Provision Follower
bin/dap --provision-follower

# Verify the deployment is working
bin/api --load-policy-and-values
bin/api --fetch-secrets

# Rotate the node certificates
bin/dap --rotate-custom-certificates

# Verify the deployment is still working
bin/api --load-policy-and-values
bin/api --fetch-secrets
```