### PR TITLE
Updated start script to not allocate tty

### DIFF
--- a/bin/dap
+++ b/bin/dap
@@ -48,7 +48,7 @@ function _run {
   echo "Running Command (on $_node_name): docker exec cyberark-dap $_args"
 
   if [[ $DRY_RUN = false ]]; then
-    docker-compose exec $_node_name bash -c "
+    docker-compose exec -T $_node_name bash -c "
       $_args
     "
   fi


### PR DESCRIPTION
This change allows dap-intro to run properly in Jenkins CI for use in integration tests.

Related to [OpenAPI PR](https://github.com/cyberark/conjur-openapi-spec/pull/143)